### PR TITLE
Fix Chat data type bug

### DIFF
--- a/app/frontend/src/component/modal/content/chat/ChatRoomContent.tsx
+++ b/app/frontend/src/component/modal/content/chat/ChatRoomContent.tsx
@@ -35,7 +35,7 @@ function submitMessage(e: any, myInfo: UserInfo,
       time: new Date().getTime(),
       message: message
     }, ...chatLog]);
-    socket.emit("message", {msg: message});
+    socket.emit("message", message);
     setMessage("");
   }
 };


### PR DESCRIPTION
클라이언트에서 data 타입을 객체({msg: string})로 보내는 바람에 문제가 생겼습니다. 이 부분 string으로 보내는 것으로 수정했습니다.