### PR TITLE
Use window.location.origin for fetch instead of "127.0.0.1"

### DIFF
--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -12,7 +12,7 @@ declare global {
   }
 }
 
-global.BE_HOST = "http://127.0.0.1";
+global.BE_HOST = window.location.origin;
 global.socket = io(`${global.BE_HOST}/global`);
 
 const element =


### PR DESCRIPTION
## 사용시의 이점
127.0.0.1 에서 호스팅 하고 있으면 127.0.0.1/??? 로 요청(fetch)를 보내고,
xxx.xxx.x.xx 에서 호스팅 하고 있으면 xxx.xxx.x.xx/??? 로 요청을 보냅니다.
즉 호스팅 주소가 바뀔 때 마다 하드코딩을 다시 할 필요가 없어집니다.

close #348 