### PR TITLE
Fix mainpage buttons container display

### DIFF
--- a/app/frontend/src/component/mainpage/MainPage.tsx
+++ b/app/frontend/src/component/mainpage/MainPage.tsx
@@ -93,7 +93,7 @@ const MainPage = ({match}): JSX.Element => {
         <Route path={`${match.path}/spectate`}><Modal id={Date.now()} content={<GameSpectateContent />} /></Route>
       </Switch>
       <main>
-        <Route path={`${match.path}`} exact>
+        <Route path={`${match.path}`}>
           <div id="button-container">
             <Link
               to={`${match.url}/record`}

--- a/app/frontend/src/component/mainpage/navbar/NavBar.tsx
+++ b/app/frontend/src/component/mainpage/navbar/NavBar.tsx
@@ -99,14 +99,20 @@ const NavBar: FC<NavBarProps> = (props): JSX.Element => {
 
           {/* user가 어드민이고, 현재 location이 mainpage인 경우 adminView로 이동할 수 있는 버튼을 보여줌*/}
           {userInfo.admin === true && history.location.pathname === "/mainpage" &&
-            <Link to={`${props.match.url}/adminView`} className="nav-list-button">
+            <Link
+              to={`${props.match.url}/adminView`}
+              className="nav-list-button"
+              onClick={() => {document.getElementById("button-container").style.display = "none"}}>
               <img className="nav-list-img" src="/public/tools.svg"/>
               <span className="nav-list-span">관리자 모드</span>
             </Link>
           }
-          {/* user가 어드민이고, 현재 location이 adminView 경우 mainpage인 이동할 수 있는 버튼을 보여줌*/}
+          {/* user가 어드민이고, 현재 location이 adminView 경우 mainpage로 이동할 수 있는 버튼을 보여줌*/}
           {userInfo.admin === true && history.location.pathname === "/mainpage/adminView" &&
-            <Link to={`${props.match.url}`} className="nav-list-button">
+            <Link
+              to={`${props.match.url}`}
+              className="nav-list-button"
+              onClick={() => {document.getElementById("button-container").style.display = "grid"}}>
               <img className="nav-list-img" src="/public/tools.svg"/>
               <span className="nav-list-span">유저 모드</span>
             </Link>


### PR DESCRIPTION
buttons container 가 정확히 /mainpage 에 있을 때만 라우트 되기 때문에 모달 창이 띄워지면 버튼 컨테이너가 사라지는 문제 해결

buttons container 의 라우터 부분에 exact 를 제거하고 adminView 를 활성화 할 때는 buttons container의 display 속성을 활용해서
보이지 않도록 설정함